### PR TITLE
Webpage title VATSIM UK branding

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -128,7 +128,7 @@
         generateSquawk();
       }
     </script>
-    <title>VATSIM-UK Squawk Code Allocator</title>
+    <title>VATSIM UK Squawk Code Allocator</title>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
Simply changed VATSIM-UK to VATSIM UK in index.php